### PR TITLE
Issue w/ Mapper reference in Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,7 @@ class Client
         if ($this->configuration->getMapper())
             $this->json_mapper = $this->configuration->getMapper();
         else
-            $this->json_mapper = new \Jira\Mapper();
+            $this->json_mapper = new \Jira\Api\Mapper();
 
         self::$jMapper = $this->json_mapper;
         // create logger


### PR DESCRIPTION
Line 73 fails with =  $this->json_mapper = new \Jira\Mapper();

the Mapper path is wrong it works if i set it to =  $this->json_mapper = new \Jira\Api\Mapper();

Need to make it Jira\Api\Mapper();

else it fails to find the mapper
